### PR TITLE
bug fix. renew_ticket not aware ignore_ip.

### DIFF
--- a/lib/Catalyst/Authentication/Store/AuthTkt.pm
+++ b/lib/Catalyst/Authentication/Store/AuthTkt.pm
@@ -257,7 +257,7 @@ sub renew_ticket {
         }
         my $new_ticket = $authtkt->ticket(
             uid     => $ticket->{uid},
-            ip_addr => $c->request->address,
+            ip_addr => $self->config->{use_req_address} || $c->request->address,
             data    => $ticket->{data},
             tokens  => $ticket->{tokens},
         );

--- a/t/02-ignore_ip.t
+++ b/t/02-ignore_ip.t
@@ -2,6 +2,10 @@
 use strict;
 use Test::More tests => 21;
 
+BEGIN {
+    $ENV{MYAPP_CONFIG} = 't/MyApp/myapp_ignore_ip.conf';
+}
+
 use lib 't/MyApp/lib';
 use Catalyst::Test 'MyApp';
 use HTTP::Request::Common;
@@ -73,7 +77,7 @@ is( $res->headers->{location},
 ok( my $AAT = Apache::AuthTkt->new( secret => $secret, ), "new AAT" );
 ok( my $auth_ticket = $AAT->ticket(
         uid     => 'catalyst-tester',
-        ip_addr => '127.0.0.1',
+        ip_addr => '0.0.0.0',
         tokens  => 'group1,group2',
         data    => 'foo bar baz'
     ),
@@ -100,7 +104,7 @@ is( $res->headers->{location},
 ok( my $stale_tkt = $AAT->ticket(
         uid     => 'catalyst-tester',
         ts      => time() - 7201,      # in the past beyond the timeout period
-        ip_addr => '127.0.0.1',
+        ip_addr => '0.0.0.0',
     ),
     "create stale ticket"
 );
@@ -111,7 +115,7 @@ is( $res->headers->{status}, 302, "stale ticket redirects" );
 ok( my $used_tkt = $AAT->ticket(
         uid     => 'catalyst-tester',
         ts      => time() - 7000,       # in the past but before timeout
-        ip_addr => '127.0.0.1',
+        ip_addr => '0.0.0.0',
     ),
     "create used ticket"
 );

--- a/t/MyApp/myapp_ignore_ip.conf
+++ b/t/MyApp/myapp_ignore_ip.conf
@@ -1,0 +1,38 @@
+name MyApp
+<Controller::Root>
+    auth_url http://localhost:3000/login
+</Controller::Root>
+<Plugin::Authentication>
+    default_realm authtkt
+    <realms>
+        <authtkt>
+            class AuthTkt
+            <credential>
+                class AuthTkt
+            </credential>
+            <store>
+                class AuthTkt
+                
+                cookie_name auth_tkt
+
+                ignore_ip 1
+                use_req_address 0.0.0.0
+                
+                # either the path to your Apache .conf file
+                #conf path/to/httpd.conf
+                
+                # or set the secret string explicitly
+                secret fee fi fo fum
+                
+                # these next two are the Apache::AuthTkt defaults
+                timeout         2h
+                timeout_refresh 0.50
+                
+                # explicitly define a domain for the cookie
+                # NOTE the leading dot means every host in the subdomain
+                domain .localhost.local
+
+            </store>
+        </authtkt>
+    </realms>
+</Plugin::Authentication>


### PR DESCRIPTION
Does renew_ticket work with ignore_ip as well?